### PR TITLE
Issue #5: delete answer minimum requirement

### DIFF
--- a/src/pages/QuizBuilder.jsx
+++ b/src/pages/QuizBuilder.jsx
@@ -280,6 +280,7 @@ const QuizBuilder = ({adminId}) => {
     )}
     </Button>
     <Button
+      disabled={question.options?.length < 3} 
       className="ml-4 whitespace-nowrap"
       size="sm"
       type="Button"


### PR DESCRIPTION
Disables the `delete answer` button when the answer count is less than 3, essentially making a minimum of 2 answers required.

> Suggested by issue title